### PR TITLE
feat: Add TacticsAgent, TacticsCenter, and related classes

### DIFF
--- a/adf_core_python/core/component/tactics/tactics_agent.py
+++ b/adf_core_python/core/component/tactics/tactics_agent.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, List, Optional
+
+if TYPE_CHECKING:
+    from adf_core_python.core.agent.communication.message_manager import MessageManager
+    from adf_core_python.core.agent.develop.develop_data import DevelopData
+    from adf_core_python.core.agent.info.agent_info import AgentInfo
+    from adf_core_python.core.agent.info.scenario_info import ScenarioInfo
+    from adf_core_python.core.agent.info.world_info import WorldInfo
+    from adf_core_python.core.agent.module.module_manager import ModuleManager
+    from adf_core_python.core.agent.precompute.precompute_data import PrecomputeData
+    from adf_core_python.core.component.extaction.ext_action import ExtAction
+    from adf_core_python.core.component.module.abstract_module import AbstractModule
+
+
+class TacticsAgent(ABC):
+    def __init__(self, parent: Optional[TacticsAgent] = None) -> None:
+        self._parent = parent
+        self._modules: List[AbstractModule] = []
+        self._actions: List[ExtAction] = []
+        self._command_executor: Any = None
+
+    @abstractmethod
+    def initialize(
+        self,
+        agent_info: AgentInfo,
+        world_info: WorldInfo,
+        scenario_info: ScenarioInfo,
+        module_manager: ModuleManager,
+        precompute_data: PrecomputeData,
+        message_manager: MessageManager,
+        develop_data: DevelopData,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def precompute(
+        self,
+        agent_info: AgentInfo,
+        world_info: WorldInfo,
+        scenario_info: ScenarioInfo,
+        module_manager: ModuleManager,
+        precompute_data: PrecomputeData,
+        message_manager: MessageManager,
+        develop_data: DevelopData,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def resume(
+        self,
+        agent_info: AgentInfo,
+        world_info: WorldInfo,
+        scenario_info: ScenarioInfo,
+        module_manager: ModuleManager,
+        precompute_data: PrecomputeData,
+        message_manager: MessageManager,
+        develop_data: DevelopData,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def prepare(
+        self,
+        agent_info: AgentInfo,
+        world_info: WorldInfo,
+        scenario_info: ScenarioInfo,
+        module_manager: ModuleManager,
+        precompute_data: PrecomputeData,
+        develop_data: DevelopData,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_info(
+        self,
+        agent_info: AgentInfo,
+        world_info: WorldInfo,
+        scenario_info: ScenarioInfo,
+        module_manager: ModuleManager,
+        precompute_data: PrecomputeData,
+        message_manager: MessageManager,
+        develop_data: DevelopData,
+    ) -> None:
+        raise NotImplementedError
+
+    def get_parent_tactics(self) -> Optional[TacticsAgent]:
+        return self._parent
+
+    def register_module(self, module: AbstractModule) -> None:
+        self._modules.append(module)
+
+    def unregister_module(self, module: AbstractModule) -> None:
+        self._modules.remove(module)
+
+    def register_action(self, action: ExtAction) -> None:
+        self._actions.append(action)
+
+    def unregister_action(self, action: ExtAction) -> None:
+        self._actions.remove(action)
+
+    def register_command_executor(self, command_executor: Any) -> None:
+        self._command_executor = command_executor
+
+    def unregister_command_executor(self) -> None:
+        self._command_executor = None
+
+    def module_precompute(self, precompute_data: PrecomputeData) -> None:
+        for module in self._modules:
+            module.precompute(precompute_data)
+        for action in self._actions:
+            action.precompute(precompute_data)
+        for executor in self._command_executor:
+            executor.precompute(precompute_data)
+
+    def module_resume(self, precompute_data: PrecomputeData) -> None:
+        for module in self._modules:
+            module.resume(precompute_data)
+        for action in self._actions:
+            action.resume(precompute_data)
+        for executor in self._command_executor:
+            executor.resume(precompute_data)
+
+    def module_prepare(self) -> None:
+        for module in self._modules:
+            module.prepare()
+        for action in self._actions:
+            action.prepare()
+        for executor in self._command_executor:
+            executor.prepare()
+
+    def module_update_info(self, message_manager: MessageManager) -> None:
+        for module in self._modules:
+            module.update_info(message_manager)
+        for action in self._actions:
+            action.update_info(message_manager)
+        for executor in self._command_executor:
+            executor.update_info(message_manager)

--- a/adf_core_python/core/component/tactics/tactics_ambulance_center.py
+++ b/adf_core_python/core/component/tactics/tactics_ambulance_center.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from adf_core_python.core.component.tactics.tactics_center import TacticsCenter
+
+
+class TacticsAmbulanceCenter(TacticsCenter):
+    def __init__(self, parent: Optional[TacticsAmbulanceCenter] = None) -> None:
+        super().__init__(parent)

--- a/adf_core_python/core/component/tactics/tactics_ambulance_team.py
+++ b/adf_core_python/core/component/tactics/tactics_ambulance_team.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from adf_core_python.core.component.tactics.tactics_agent import TacticsAgent
+
+
+class TacticsAmbulanceTeam(TacticsAgent):
+    def __init__(self, parent: Optional[TacticsAmbulanceTeam] = None) -> None:
+        super().__init__(parent)

--- a/adf_core_python/core/component/tactics/tactics_center.py
+++ b/adf_core_python/core/component/tactics/tactics_center.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, List, Optional
+
+if TYPE_CHECKING:
+    from adf_core_python.core.agent.communication.message_manager import MessageManager
+    from adf_core_python.core.agent.develop.develop_data import DevelopData
+    from adf_core_python.core.agent.info.agent_info import AgentInfo
+    from adf_core_python.core.agent.info.scenario_info import ScenarioInfo
+    from adf_core_python.core.agent.info.world_info import WorldInfo
+    from adf_core_python.core.agent.module.module_manager import ModuleManager
+    from adf_core_python.core.agent.precompute.precompute_data import PrecomputeData
+    from adf_core_python.core.component.module.abstract_module import AbstractModule
+
+
+class TacticsCenter(ABC):
+    def __init__(self, parent: Optional[TacticsCenter] = None) -> None:
+        self._parent = parent
+        self._modules: List[AbstractModule] = []
+        self._command_pickers: List[Any] = []
+
+    @abstractmethod
+    def initialize(
+        self,
+        agent_info: AgentInfo,
+        world_info: WorldInfo,
+        scenario_info: ScenarioInfo,
+        module_manager: ModuleManager,
+        precompute_data: PrecomputeData,
+        message_manager: MessageManager,
+        develop_data: DevelopData,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def resume(
+        self,
+        agent_info: AgentInfo,
+        world_info: WorldInfo,
+        scenario_info: ScenarioInfo,
+        module_manager: ModuleManager,
+        precompute_data: PrecomputeData,
+        message_manager: MessageManager,
+        develop_data: DevelopData,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def prepare(
+        self,
+        agent_info: AgentInfo,
+        world_info: WorldInfo,
+        scenario_info: ScenarioInfo,
+        module_manager: ModuleManager,
+        precompute_data: PrecomputeData,
+        develop_data: DevelopData,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def think(
+        self,
+        agent_info: AgentInfo,
+        world_info: WorldInfo,
+        scenario_info: ScenarioInfo,
+        module_manager: ModuleManager,
+        precompute_data: PrecomputeData,
+        message_manager: MessageManager,
+        develop_data: DevelopData,
+    ) -> None:
+        raise NotImplementedError
+
+    def get_parent_tactics(self) -> Optional[TacticsCenter]:
+        return self._parent
+
+    def register_module(self, module: AbstractModule) -> None:
+        self._modules.append(module)
+
+    def unregister_module(self, module: AbstractModule) -> None:
+        self._modules.remove(module)
+
+    def register_command_picker(self, command_picker: Any) -> None:
+        self._command_pickers.append(command_picker)
+
+    def unregister_command_picker(self, command_picker: Any) -> None:
+        self._command_pickers.remove(command_picker)
+
+    def module_precompute(self, precompute_data: PrecomputeData) -> None:
+        for module in self._modules:
+            module.precompute(precompute_data)
+        for command_picker in self._command_pickers:
+            command_picker.precompute(precompute_data)
+
+    def module_resume(self, precompute_data: PrecomputeData) -> None:
+        for module in self._modules:
+            module.resume(precompute_data)
+        for command_picker in self._command_pickers:
+            command_picker.resume(precompute_data)
+
+    def module_prepare(self) -> None:
+        for module in self._modules:
+            module.prepare()
+        for command_picker in self._command_pickers:
+            command_picker.prepare()
+
+    def module_update_info(self, message_manager: MessageManager) -> None:
+        for module in self._modules:
+            module.update_info(message_manager)
+        for command_picker in self._command_pickers:
+            command_picker.update_info(message_manager)

--- a/adf_core_python/core/component/tactics/tactics_fire_brigade.py
+++ b/adf_core_python/core/component/tactics/tactics_fire_brigade.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from adf_core_python.core.component.tactics.tactics_agent import TacticsAgent
+
+
+class TacticsFireBrigade(TacticsAgent):
+    def __init__(self, parent: Optional[TacticsFireBrigade] = None) -> None:
+        super().__init__(parent)

--- a/adf_core_python/core/component/tactics/tactics_fire_station.py
+++ b/adf_core_python/core/component/tactics/tactics_fire_station.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from adf_core_python.core.component.tactics.tactics_center import TacticsCenter
+
+
+class TacticsFireStation(TacticsCenter):
+    def __init__(self, parent: Optional[TacticsFireStation] = None) -> None:
+        super().__init__(parent)

--- a/adf_core_python/core/component/tactics/tactics_police_force.py
+++ b/adf_core_python/core/component/tactics/tactics_police_force.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from adf_core_python.core.component.tactics.tactics_agent import TacticsAgent
+
+
+class TacticsPoliceForce(TacticsAgent):
+    def __init__(self, parent: Optional[TacticsPoliceForce] = None) -> None:
+        super().__init__(parent)

--- a/adf_core_python/core/component/tactics/tactics_police_office.py
+++ b/adf_core_python/core/component/tactics/tactics_police_office.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from adf_core_python.core.component.tactics.tactics_center import TacticsCenter
+
+
+class TacticsPoliceOffice(TacticsCenter):
+    def __init__(self, parent: Optional[TacticsPoliceOffice] = None) -> None:
+        super().__init__(parent)


### PR DESCRIPTION
## Overview

adf/core/component/tactics/*の実装をした。
tactics -> tactics_agentに名前を変更した。
closed #29

## Reason
tactics_centerの基底クラスに使われているわけでもないので、tactics_centerと合わせるために名前を変えた。