### PR TITLE
fix: Rename modules from ExtAction to ExtendAction

### DIFF
--- a/adf_core_python/core/agent/module/module_manager.py
+++ b/adf_core_python/core/agent/module/module_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 from typing import TYPE_CHECKING, Any
 
-from adf_core_python.core.component.extaction.ext_action import ExtAction
+from adf_core_python.core.component.action.extend_action import ExtendAction
 from adf_core_python.core.component.module.abstract_module import AbstractModule
 
 if TYPE_CHECKING:
@@ -29,7 +29,7 @@ class ModuleManager:
         self._module_config = module_config
         self._develop_data = develop_data
         self._modules: dict[str, AbstractModule] = {}
-        self._actions: dict[str, ExtAction] = {}
+        self._actions: dict[str, ExtendAction] = {}
 
         self._executors: dict[str, Any] = {}
         self._pickers: dict[str, Any] = {}
@@ -63,7 +63,9 @@ class ModuleManager:
 
         raise RuntimeError(f"Module {class_name} is not a subclass of AbstractModule")
 
-    def get_ext_action(self, action_name: str, default_action_name: str) -> ExtAction:
+    def get_extend_action(
+        self, action_name: str, default_action_name: str
+    ) -> ExtendAction:
         class_name = self._module_config.get_value_or_default(
             action_name, default_action_name
         )
@@ -77,7 +79,7 @@ class ModuleManager:
         if instance is not None:
             return instance
 
-        if issubclass(action_class, ExtAction):
+        if issubclass(action_class, ExtendAction):
             instance = action_class(
                 self._agent_info,
                 self._world_info,
@@ -88,7 +90,7 @@ class ModuleManager:
             self._actions[action_name] = instance
             return instance
 
-        raise RuntimeError(f"Action {class_name} is not a subclass of ExtAction")
+        raise RuntimeError(f"Action {class_name} is not a subclass of ExtendAction")
 
     def _load_module(self, class_name: str) -> type:
         module_name, module_class_name = class_name.rsplit(".", 1)

--- a/adf_core_python/core/component/action/extend_action.py
+++ b/adf_core_python/core/component/action/extend_action.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from adf_core_python.core.agent.precompute.precompute_data import PrecomputeData
 
 
-class ExtAction(ABC):
+class ExtendAction(ABC):
     def __init__(
         self,
         agent_info: AgentInfo,
@@ -38,29 +38,29 @@ class ExtAction(ABC):
         self.count_update_info_current_time: int = 0
 
     @abstractmethod
-    def set_target_entity_id(self, target_entity_id: EntityID) -> ExtAction:
+    def set_target_entity_id(self, target_entity_id: EntityID) -> ExtendAction:
         raise NotImplementedError
 
     @abstractmethod
-    def calc(self) -> ExtAction:
+    def calc(self) -> ExtendAction:
         raise NotImplementedError
 
     def get_action(self) -> Optional[Action]:
         return self.result
 
-    def precompute(self, precompute_data: PrecomputeData) -> ExtAction:
+    def precompute(self, precompute_data: PrecomputeData) -> ExtendAction:
         self.count_precompute += 1
         return self
 
-    def resume(self, precompute_data: PrecomputeData) -> ExtAction:
+    def resume(self, precompute_data: PrecomputeData) -> ExtendAction:
         self.count_resume += 1
         return self
 
-    def prepare(self) -> ExtAction:
+    def prepare(self) -> ExtendAction:
         self.count_prepare += 1
         return self
 
-    def update_info(self, message_manager: MessageManager) -> ExtAction:
+    def update_info(self, message_manager: MessageManager) -> ExtendAction:
         self.count_update_info += 1
         return self
 

--- a/adf_core_python/core/component/tactics/tactics_agent.py
+++ b/adf_core_python/core/component/tactics/tactics_agent.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from adf_core_python.core.agent.info.world_info import WorldInfo
     from adf_core_python.core.agent.module.module_manager import ModuleManager
     from adf_core_python.core.agent.precompute.precompute_data import PrecomputeData
-    from adf_core_python.core.component.extaction.ext_action import ExtAction
+    from adf_core_python.core.component.action.extend_action import ExtendAction
     from adf_core_python.core.component.module.abstract_module import AbstractModule
 
 
@@ -22,7 +22,7 @@ class TacticsAgent(ABC):
     def __init__(self, parent: Optional[TacticsAgent] = None) -> None:
         self._parent = parent
         self._modules: list[AbstractModule] = []
-        self._actions: list[ExtAction] = []
+        self._actions: list[ExtendAction] = []
         self._command_executor: Any = None
 
     @abstractmethod
@@ -100,10 +100,10 @@ class TacticsAgent(ABC):
     def unregister_module(self, module: AbstractModule) -> None:
         self._modules.remove(module)
 
-    def register_action(self, action: ExtAction) -> None:
+    def register_action(self, action: ExtendAction) -> None:
         self._actions.append(action)
 
-    def unregister_action(self, action: ExtAction) -> None:
+    def unregister_action(self, action: ExtendAction) -> None:
         self._actions.remove(action)
 
     def register_command_executor(self, command_executor: Any) -> None:

--- a/adf_core_python/core/launcher/config_key.py
+++ b/adf_core_python/core/launcher/config_key.py
@@ -3,7 +3,7 @@ from typing import Final
 
 class ConfigKey:
     # General
-    KEY_LOADER_CLASS: Final[str] = "adf.launcher.loader"
+    KEY_LOADER_CLASS: Final[str] = "adf_core_python.launcher.loader"
     KEY_KERNEL_HOST: Final[str] = "kernel.host"
     KEY_KERNEL_PORT: Final[str] = "kernel.port"
     KEY_TEAM_NAME: Final[str] = "team.name"

--- a/adf_core_python/implement/action/default_extend_action_move.py
+++ b/adf_core_python/implement/action/default_extend_action_move.py
@@ -15,11 +15,11 @@ from adf_core_python.core.agent.info.scenario_info import Mode, ScenarioInfo
 from adf_core_python.core.agent.info.world_info import WorldInfo
 from adf_core_python.core.agent.module.module_manager import ModuleManager
 from adf_core_python.core.agent.precompute.precompute_data import PrecomputeData
-from adf_core_python.core.component.extaction.ext_action import ExtAction
+from adf_core_python.core.component.action.extend_action import ExtendAction
 from adf_core_python.core.component.module.algorithm.path_planning import PathPlanning
 
 
-class DefaultExtendActionMove(ExtAction):
+class DefaultExtendActionMove(ExtendAction):
     def __init__(
         self,
         agent_info: AgentInfo,
@@ -49,35 +49,35 @@ class DefaultExtendActionMove(ExtAction):
             case Mode.PRECOMPUTED:
                 pass
 
-    def precompute(self, precompute_data: PrecomputeData) -> ExtAction:
+    def precompute(self, precompute_data: PrecomputeData) -> ExtendAction:
         super().precompute(precompute_data)
         if self.get_count_precompute() > 1:
             return self
         self._path_planning.precompute(precompute_data)
         return self
 
-    def resume(self, precompute_data: PrecomputeData) -> ExtAction:
+    def resume(self, precompute_data: PrecomputeData) -> ExtendAction:
         super().resume(precompute_data)
         if self.get_count_resume() > 1:
             return self
         self._path_planning.resume(precompute_data)
         return self
 
-    def prepare(self) -> ExtAction:
+    def prepare(self) -> ExtendAction:
         super().prepare()
         if self.get_count_prepare() > 1:
             return self
         self._path_planning.prepare()
         return self
 
-    def update_info(self, message_manager: MessageManager) -> ExtAction:
+    def update_info(self, message_manager: MessageManager) -> ExtendAction:
         super().update_info(message_manager)
         if self.get_count_update_info() > 1:
             return self
         self._path_planning.update_info(message_manager)
         return self
 
-    def set_target_entity_id(self, target_entity_id: EntityID) -> ExtAction:
+    def set_target_entity_id(self, target_entity_id: EntityID) -> ExtendAction:
         entity: Optional[Entity] = self.world_info.get_entity(target_entity_id)
         self._target_entity_id = None
 
@@ -94,7 +94,7 @@ class DefaultExtendActionMove(ExtAction):
 
         return self
 
-    def calc(self) -> ExtAction:
+    def calc(self) -> ExtendAction:
         self.result = None
         agent: Human = cast(Human, self.agent_info.get_myself())
 

--- a/adf_core_python/implement/action/default_extend_action_transport.py
+++ b/adf_core_python/implement/action/default_extend_action_transport.py
@@ -19,13 +19,13 @@ from adf_core_python.core.agent.info.scenario_info import Mode, ScenarioInfo
 from adf_core_python.core.agent.info.world_info import WorldInfo
 from adf_core_python.core.agent.module.module_manager import ModuleManager
 from adf_core_python.core.agent.precompute.precompute_data import PrecomputeData
-from adf_core_python.core.component.extaction.ext_action import ExtAction
+from adf_core_python.core.component.action.extend_action import ExtendAction
 from adf_core_python.core.component.module.algorithm.path_planning import PathPlanning
 from adf_core_python.core.logger.logger import get_agent_logger
 
 
 # TODO: refactor this class
-class DefaultExtendActionTransport(ExtAction):
+class DefaultExtendActionTransport(ExtendAction):
     def __init__(
         self,
         agent_info: AgentInfo,
@@ -58,35 +58,35 @@ class DefaultExtendActionTransport(ExtAction):
             case Mode.PRECOMPUTED:
                 pass
 
-    def precompute(self, precompute_data: PrecomputeData) -> ExtAction:
+    def precompute(self, precompute_data: PrecomputeData) -> ExtendAction:
         super().precompute(precompute_data)
         if self.get_count_precompute() > 1:
             return self
         self._path_planning.precompute(precompute_data)
         return self
 
-    def resume(self, precompute_data: PrecomputeData) -> ExtAction:
+    def resume(self, precompute_data: PrecomputeData) -> ExtendAction:
         super().resume(precompute_data)
         if self.get_count_resume() > 1:
             return self
         self._path_planning.resume(precompute_data)
         return self
 
-    def prepare(self) -> ExtAction:
+    def prepare(self) -> ExtendAction:
         super().prepare()
         if self.get_count_prepare() > 1:
             return self
         self._path_planning.prepare()
         return self
 
-    def update_info(self, message_manager: MessageManager) -> ExtAction:
+    def update_info(self, message_manager: MessageManager) -> ExtendAction:
         super().update_info(message_manager)
         if self.get_count_update_info() > 1:
             return self
         self._path_planning.update_info(message_manager)
         return self
 
-    def set_target_entity_id(self, target_entity_id: EntityID) -> ExtAction:
+    def set_target_entity_id(self, target_entity_id: EntityID) -> ExtendAction:
         entity: Optional[Entity] = self.world_info.get_world_model().get_entity(
             target_entity_id
         )
@@ -100,7 +100,7 @@ class DefaultExtendActionTransport(ExtAction):
 
         return self
 
-    def calc(self) -> ExtAction:
+    def calc(self) -> ExtendAction:
         self._result = None
         agent: AmbulanceTeamEntity = cast(
             AmbulanceTeamEntity, self.agent_info.get_myself()

--- a/adf_core_python/implement/tactics/default_tactics_ambulance_team.py
+++ b/adf_core_python/implement/tactics/default_tactics_ambulance_team.py
@@ -55,13 +55,13 @@ class DefaultTacticsAmbulanceTeam(TacticsAmbulanceTeam):
                         "adf_core_python.core.component.module.complex.human_detector.HumanDetector",
                     ),
                 )
-                self._action_transport = module_manager.get_ext_action(
-                    "DefaultTacticsAmbulanceTeam.ExtActionTransport",
-                    "adf_core_python.implement.extend_action.default_extend_action_transport.DefaultExtendActionTransport",
+                self._action_transport = module_manager.get_extend_action(
+                    "DefaultTacticsAmbulanceTeam.ExtendActionTransport",
+                    "adf_core_python.implement.action.default_extend_action_transport.DefaultExtendActionTransport",
                 )
-                self._action_ext_move = module_manager.get_ext_action(
-                    "DefaultTacticsAmbulanceTeam.ExtActionMove",
-                    "adf_core_python.implement.extend_action.default_extend_action_move.DefaultExtendActionMove",
+                self._action_ext_move = module_manager.get_extend_action(
+                    "DefaultTacticsAmbulanceTeam.ExtendActionMove",
+                    "adf_core_python.implement.action.default_extend_action_move.DefaultExtendActionMove",
                 )
         self.register_module(self._search)
         self.register_module(self._human_detector)

--- a/adf_core_python/implement/tactics/default_tactics_fire_brigade.py
+++ b/adf_core_python/implement/tactics/default_tactics_fire_brigade.py
@@ -46,13 +46,13 @@ class DefaultTacticsFireBrigade(TacticsFireBrigade):
                         "adf_core_python.impl.module.complex.DefaultHumanDetector",
                     ),
                 )
-                self._action_fire_rescue = module_manager.get_ext_action(
-                    "DefaultTacticsFireBrigade.ExtActionFireRescue",
-                    "adf_core_python.impl.extaction.DefaultExtActionFireRescue",
+                self._action_fire_rescue = module_manager.get_extend_action(
+                    "DefaultTacticsFireBrigade.ExtendActionRescue",
+                    "adf_core_python.implement.action.DefaultExtendActionRescue",
                 )
-                self._action_ext_move = module_manager.get_ext_action(
-                    "DefaultTacticsAmbulanceTeam.ExtActionMove",
-                    "adf_core_python.impl.extaction.DefaultExtActionMove",
+                self._action_ext_move = module_manager.get_extend_action(
+                    "DefaultTacticsAmbulanceTeam.ExtendActionMove",
+                    "adf_core_python.implement.action.DefaultExtendActionMove",
                 )
         self.register_module(self._search)
         self.register_module(self._human_detector)

--- a/adf_core_python/implement/tactics/default_tactics_police_force.py
+++ b/adf_core_python/implement/tactics/default_tactics_police_force.py
@@ -50,13 +50,13 @@ class DefaultTacticsPoliceForce(TacticsPoliceForce):
                         "adf_core_python.implement.module.complex.DefaultRoadDetector",
                     ),
                 )
-                self._action_ext_clear = module_manager.get_ext_action(
-                    "DefaultTacticsPoliceForce.ExtActionClear",
-                    "adf_core_python.implement.extaction.DefaultExtActionClear",
+                self._action_ext_clear = module_manager.get_extend_action(
+                    "DefaultTacticsPoliceForce.ExtendActionClear",
+                    "adf_core_python.implement.action.DefaultExtendActionClear",
                 )
-                self._action_ext_move = module_manager.get_ext_action(
-                    "DefaultTacticsPoliceForce.ExtActionMove",
-                    "adf_core_python.implement.extaction.DefaultExtActionMove",
+                self._action_ext_move = module_manager.get_extend_action(
+                    "DefaultTacticsPoliceForce.ExtendActionMove",
+                    "adf_core_python.implement.action.DefaultExtendActionMove",
                 )
         self.register_module(self._search)
         self.register_module(self._road_detector)

--- a/config/module.yaml
+++ b/config/module.yaml
@@ -2,43 +2,43 @@
 DefaultTacticsAmbulanceTeam:
   HumanDetector: adf_core_python.implement.module.complex.default_human_detector.DefaultHumanDetector
   Search: adf_core_python.implement.module.complex.default_search.DefaultSearch
-  ExtActionTransport: adf_core_python.implement.extend_action.default_extend_action_transport.DefaultExtendActionTransport
-  ExtActionMove: adf_core_python.implement.extend_action.default_extend_action_move.DefaultExtendActionMove
-  CommandExecutorAmbulance: adf.impl.centralized.DefaultCommandExecutorAmbulance
-  CommandExecutorScout: adf.impl.centralized.DefaultCommandExecutorScout
+  ExtendActionTransport: adf_core_python.implement.action.default_extend_action_transport.DefaultExtendActionTransport
+  ExtendActionMove: adf_core_python.implement.action.default_extend_action_move.DefaultExtendActionMove
+  CommandExecutorAmbulance: adf_core_python.implement.centralized.DefaultCommandExecutorAmbulance
+  CommandExecutorScout: adf_core_python.implement.centralized.DefaultCommandExecutorScout
 
 # ## DefaultTacticsFireBrigade
 # DefaultTacticsFireBrigade:
 #   HumanDetector: sample_team.module.complex.SampleHumanDetector
 #   Search: sample_team.module.complex.SampleSearch
-#   ExtActionFireRescue: adf.impl.extaction.DefaultExtActionFireRescue
-#   ExtActionMove: adf.impl.extaction.DefaultExtActionMove
-#   CommandExecutorFire: adf.impl.centralized.DefaultCommandExecutorFire
-#   CommandExecutorScout: adf.impl.centralized.DefaultCommandExecutorScout
+#   ExtendActionRescue: adf_core_python.implement.action.DefaultExtendActionRescue
+#   ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
+#   CommandExecutorFire: adf_core_python.implement.centralized.DefaultCommandExecutorFire
+#   CommandExecutorScout: adf_core_python.implement.centralized.DefaultCommandExecutorScout
 
 # ## DefaultTacticsPoliceForce
 # DefaultTacticsPoliceForce:
 #   RoadDetector: sample_team.module.complex.SampleRoadDetector
 #   Search: sample_team.module.complex.SampleSearch
-#   ExtActionClear: adf.impl.extaction.DefaultExtActionClear
-#   ExtActionMove: adf.impl.extaction.DefaultExtActionMove
-#   CommandExecutorPolice: adf.impl.centralized.DefaultCommandExecutorPolice
-#   CommandExecutorScout: adf.impl.centralized.DefaultCommandExecutorScoutPolice
+#   ExtendActionClear: adf_core_python.implement.action.DefaultExtendActionClear
+#   ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
+#   CommandExecutorPolice: adf_core_python.implement.centralized.DefaultCommandExecutorPolice
+#   CommandExecutorScout: adf_core_python.implement.centralized.DefaultCommandExecutorScoutPolice
 
 # ## DefaultTacticsAmbulanceCentre
 # DefaultTacticsAmbulanceCentre:
 #   TargetAllocator: sample_team.module.complex.SampleAmbulanceTargetAllocator
-#   CommandPicker: adf.impl.centralized.DefaultCommandPickerAmbulance
+#   CommandPicker: adf_core_python.implement.centralized.DefaultCommandPickerAmbulance
 
 # ## DefaultTacticsFireStation
 # DefaultTacticsFireStation:
 #   TargetAllocator: sample_team.module.complex.SampleFireTargetAllocator
-#   CommandPicker: adf.impl.centralized.DefaultCommandPickerFire
+#   CommandPicker: adf_core_python.implement.centralized.DefaultCommandPickerFire
 
 # ## DefaultTacticsPoliceOffice
 # DefaultTacticsPoliceOffice:
 #   TargetAllocator: sample_team.module.complex.SamplePoliceTargetAllocator
-#   CommandPicker: adf.impl.centralized.DefaultCommandPickerPolice
+#   CommandPicker: adf_core_python.implement.centralized.DefaultCommandPickerPolice
 
 ## SampleSearch
 SampleSearch:
@@ -47,70 +47,70 @@ SampleSearch:
 
 # ## SampleBuildDetector
 # SampleBuildingDetector:
-#   Clustering: adf.impl.module.algorithm.KMeansClustering
+#   Clustering: adf_core_python.implement.module.algorithm.KMeansClustering
 
 # ## SampleRoadDetector
 # SampleRoadDetector:
-#   Clustering: adf.impl.module.algorithm.KMeansClustering
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+#   Clustering: adf_core_python.implement.module.algorithm.KMeansClustering
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
 # ## SampleHumanDetector
 # SampleHumanDetector:
-#   Clustering: adf.impl.module.algorithm.KMeansClustering
+#   Clustering: adf_core_python.implement.module.algorithm.KMeansClustering
 
-# ## DefaultExtActionClear
-# DefaultExtActionClear:
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+# ## DefaultExtendActionClear
+# DefaultExtendActionClear:
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-# ## DefaultExtActionFireFighting
-# DefaultExtActionFireFighting:
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+# ## DefaultExtendActionFireFighting
+# DefaultExtendActionFireFighting:
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-# ## DefaultExtActionFireRescue
-# DefaultExtActionFireRescue:
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+# ## DefaultExtendActionRescue
+# DefaultExtendActionRescue:
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-# ## DefaultExtActionMove
-# DefaultExtActionMove:
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+# ## DefaultExtendActionMove
+# DefaultExtendActionMove:
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-# ## DefaultExtActionTransport
-# DefaultExtActionTransport:
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+# ## DefaultExtendActionTransport
+# DefaultExtendActionTransport:
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 # ## DefaultCommandExecutorAmbulance
 # DefaultCommandExecutorAmbulance:
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-#   ExtActionTransport: adf.impl.extaction.DefaultExtActionTransport
-#   ExtActionMove: adf.impl.extaction.DefaultExtActionMove
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+#   ExtendActionTransport: adf_core_python.implement.action.DefaultExtendActionTransport
+#   ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
 
 # ## DefaultCommandExecutorFire
 # DefaultCommandExecutorFire:
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-#   EtxActionFireRescue: adf.impl.extaction.DefaultExtActionFireRescue
-#   EtxActionFireFighting: adf.impl.extaction.DefaultExtActionFireFighting
-#   ExtActionMove: adf.impl.extaction.DefaultExtActionMove
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+#   EtxActionFireRescue: adf_core_python.implement.action.DefaultExtendActionRescue
+#   EtxActionFireFighting: adf_core_python.implement.action.DefaultExtendActionFireFighting
+#   ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
 
 # ## DefaultCommandExecutorPolice
 # DefaultCommandExecutorPolice:
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-#   ExtActionClear: adf.impl.extaction.DefaultExtActionClear
-#   ExtActionMove: adf.impl.extaction.DefaultExtActionMove
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+#   ExtendActionClear: adf_core_python.implement.action.DefaultExtendActionClear
+#   ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
 
 # ## DefaultCommandExecutorScout
 # DefaultCommandExecutorScout:
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
 # ## DefaultCommandExecutorScoutPolice
 # DefaultCommandExecutorScoutPolice:
-#   PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-#   ExtActionClear: adf.impl.extaction.DefaultExtActionClear
+#   PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+#   ExtendActionClear: adf_core_python.implement.action.DefaultExtendActionClear
 
 # ## MessageManager
 # MessageManager:
-#   PlatoonChannelSubscriber: adf.impl.module.comm.DefaultChannelSubscriber
-#   CenterChannelSubscriber: adf.impl.module.comm.DefaultChannelSubscriber
-#   PlatoonMessageCoordinator: adf.impl.module.comm.DefaultMessageCoordinator
-#   CenterMessageCoordinator: adf.impl.module.comm.DefaultMessageCoordinator
+#   PlatoonChannelSubscriber: adf_core_python.implement.module.comm.DefaultChannelSubscriber
+#   CenterChannelSubscriber: adf_core_python.implement.module.comm.DefaultChannelSubscriber
+#   PlatoonMessageCoordinator: adf_core_python.implement.module.comm.DefaultMessageCoordinator
+#   CenterMessageCoordinator: adf_core_python.implement.module.comm.DefaultMessageCoordinator
 
 # ## VisualDebug
 # VisualDebug: true

--- a/tests/core/agent/config/module.yaml
+++ b/tests/core/agent/config/module.yaml
@@ -2,122 +2,122 @@
 DefaultTacticsAmbulanceTeam:
   HumanDetector: sample_team.module.complex.SampleHumanDetector
   Search: sample_team.module.complex.SampleSearch
-  ExtActionTransport: adf.impl.extaction.DefaultExtActionTransport
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
-  CommandExecutorAmbulance: adf.impl.centralized.DefaultCommandExecutorAmbulance
-  CommandExecutorScout: adf.impl.centralized.DefaultCommandExecutorScout
+  ExtendActionTransport: adf_core_python.implement.action.DefaultExtendActionTransport
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
+  CommandExecutorAmbulance: adf_core_python.implement.centralized.DefaultCommandExecutorAmbulance
+  CommandExecutorScout: adf_core_python.implement.centralized.DefaultCommandExecutorScout
 
 ## DefaultTacticsFireBrigade
 DefaultTacticsFireBrigade:
   HumanDetector: sample_team.module.complex.SampleHumanDetector
   Search: sample_team.module.complex.SampleSearch
-  ExtActionFireRescue: adf.impl.extaction.DefaultExtActionFireRescue
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
-  CommandExecutorFire: adf.impl.centralized.DefaultCommandExecutorFire
-  CommandExecutorScout: adf.impl.centralized.DefaultCommandExecutorScout
+  ExtendActionRescue: adf_core_python.implement.action.DefaultExtendActionRescue
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
+  CommandExecutorFire: adf_core_python.implement.centralized.DefaultCommandExecutorFire
+  CommandExecutorScout: adf_core_python.implement.centralized.DefaultCommandExecutorScout
 
 ## DefaultTacticsPoliceForce
 DefaultTacticsPoliceForce:
   RoadDetector: sample_team.module.complex.SampleRoadDetector
   Search: sample_team.module.complex.SampleSearch
-  ExtActionClear: adf.impl.extaction.DefaultExtActionClear
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
-  CommandExecutorPolice: adf.impl.centralized.DefaultCommandExecutorPolice
-  CommandExecutorScout: adf.impl.centralized.DefaultCommandExecutorScoutPolice
+  ExtendActionClear: adf_core_python.implement.action.DefaultExtendActionClear
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
+  CommandExecutorPolice: adf_core_python.implement.centralized.DefaultCommandExecutorPolice
+  CommandExecutorScout: adf_core_python.implement.centralized.DefaultCommandExecutorScoutPolice
 
 ## DefaultTacticsAmbulanceCentre
 DefaultTacticsAmbulanceCentre:
   TargetAllocator: sample_team.module.complex.SampleAmbulanceTargetAllocator
-  CommandPicker: adf.impl.centralized.DefaultCommandPickerAmbulance
+  CommandPicker: adf_core_python.implement.centralized.DefaultCommandPickerAmbulance
 
 ## DefaultTacticsFireStation
 DefaultTacticsFireStation:
   TargetAllocator: sample_team.module.complex.SampleFireTargetAllocator
-  CommandPicker: adf.impl.centralized.DefaultCommandPickerFire
+  CommandPicker: adf_core_python.implement.centralized.DefaultCommandPickerFire
 
 ## DefaultTacticsPoliceOffice
 DefaultTacticsPoliceOffice:
   TargetAllocator: sample_team.module.complex.SamplePoliceTargetAllocator
-  CommandPicker: adf.impl.centralized.DefaultCommandPickerPolice
+  CommandPicker: adf_core_python.implement.centralized.DefaultCommandPickerPolice
 
 ## SampleSearch
 SampleSearch:
   PathPlanning:
-    Ambulance: adf.impl.module.algorithm.DijkstraPathPlanning
-    Fire: adf.impl.module.algorithm.DijkstraPathPlanning
-    Police: adf.impl.module.algorithm.DijkstraPathPlanning
+    Ambulance: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+    Fire: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+    Police: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
   Clustering:
-    Ambulance: adf.impl.module.algorithm.KMeansClustering
-    Fire: adf.impl.module.algorithm.KMeansClustering
-    Police: adf.impl.module.algorithm.KMeansClustering
+    Ambulance: adf_core_python.implement.module.algorithm.KMeansClustering
+    Fire: adf_core_python.implement.module.algorithm.KMeansClustering
+    Police: adf_core_python.implement.module.algorithm.KMeansClustering
 
 ## SampleBuildDetector
 SampleBuildingDetector:
-  Clustering: adf.impl.module.algorithm.KMeansClustering
+  Clustering: adf_core_python.implement.module.algorithm.KMeansClustering
 
 ## SampleRoadDetector
 SampleRoadDetector:
-  Clustering: adf.impl.module.algorithm.KMeansClustering
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+  Clustering: adf_core_python.implement.module.algorithm.KMeansClustering
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
 ## SampleHumanDetector
 SampleHumanDetector:
-  Clustering: adf.impl.module.algorithm.KMeansClustering
+  Clustering: adf_core_python.implement.module.algorithm.KMeansClustering
 
-## DefaultExtActionClear
-DefaultExtActionClear:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+## DefaultExtendActionClear
+DefaultExtendActionClear:
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-## DefaultExtActionFireFighting
-DefaultExtActionFireFighting:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+## DefaultExtendActionFireFighting
+DefaultExtendActionFireFighting:
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-## DefaultExtActionFireRescue
-DefaultExtActionFireRescue:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+## DefaultExtendActionRescue
+DefaultExtendActionRescue:
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-## DefaultExtActionMove
-DefaultExtActionMove:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+## DefaultExtendActionMove
+DefaultExtendActionMove:
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-## DefaultExtActionTransport
-DefaultExtActionTransport:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+## DefaultExtendActionTransport
+DefaultExtendActionTransport:
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
 ## DefaultCommandExecutorAmbulance
 DefaultCommandExecutorAmbulance:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-  ExtActionTransport: adf.impl.extaction.DefaultExtActionTransport
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+  ExtendActionTransport: adf_core_python.implement.action.DefaultExtendActionTransport
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
 
 ## DefaultCommandExecutorFire
 DefaultCommandExecutorFire:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-  EtxActionFireRescue: adf.impl.extaction.DefaultExtActionFireRescue
-  EtxActionFireFighting: adf.impl.extaction.DefaultExtActionFireFighting
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+  EtxActionFireRescue: adf_core_python.implement.action.DefaultExtendActionRescue
+  EtxActionFireFighting: adf_core_python.implement.action.DefaultExtendActionFireFighting
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
 
 ## DefaultCommandExecutorPolice
 DefaultCommandExecutorPolice:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-  ExtActionClear: adf.impl.extaction.DefaultExtActionClear
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+  ExtendActionClear: adf_core_python.implement.action.DefaultExtendActionClear
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
 
 ## DefaultCommandExecutorScout
 DefaultCommandExecutorScout:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
 ## DefaultCommandExecutorScoutPolice
 DefaultCommandExecutorScoutPolice:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-  ExtActionClear: adf.impl.extaction.DefaultExtActionClear
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+  ExtendActionClear: adf_core_python.implement.action.DefaultExtendActionClear
 
 ## MessageManager
 MessageManager:
-  PlatoonChannelSubscriber: adf.impl.module.comm.DefaultChannelSubscriber
-  CenterChannelSubscriber: adf.impl.module.comm.DefaultChannelSubscriber
-  PlatoonMessageCoordinator: adf.impl.module.comm.DefaultMessageCoordinator
-  CenterMessageCoordinator: adf.impl.module.comm.DefaultMessageCoordinator
+  PlatoonChannelSubscriber: adf_core_python.implement.module.comm.DefaultChannelSubscriber
+  CenterChannelSubscriber: adf_core_python.implement.module.comm.DefaultChannelSubscriber
+  PlatoonMessageCoordinator: adf_core_python.implement.module.comm.DefaultMessageCoordinator
+  CenterMessageCoordinator: adf_core_python.implement.module.comm.DefaultMessageCoordinator
 
 ## VisualDebug
 VisualDebug: true

--- a/tests/core/agent/config/test_module_config.py
+++ b/tests/core/agent/config/test_module_config.py
@@ -16,31 +16,31 @@ class TestModuleConfig:
         )
         assert (
             config.get_value("DefaultTacticsPoliceOffice.CommandPicker")
-            == "adf.impl.centralized.DefaultCommandPickerPolice"
+            == "adf_core_python.implement.centralized.DefaultCommandPickerPolice"
         )
         assert (
             config.get_value("SampleSearch.PathPlanning.Ambulance")
-            == "adf.impl.module.algorithm.DijkstraPathPlanning"
+            == "adf_core_python.implement.module.algorithm.DijkstraPathPlanning"
         )
         assert (
             config.get_value("SampleSearch.PathPlanning.Fire")
-            == "adf.impl.module.algorithm.DijkstraPathPlanning"
+            == "adf_core_python.implement.module.algorithm.DijkstraPathPlanning"
         )
         assert (
             config.get_value("SampleSearch.PathPlanning.Police")
-            == "adf.impl.module.algorithm.DijkstraPathPlanning"
+            == "adf_core_python.implement.module.algorithm.DijkstraPathPlanning"
         )
         assert (
             config.get_value("SampleSearch.Clustering.Ambulance")
-            == "adf.impl.module.algorithm.KMeansClustering"
+            == "adf_core_python.implement.module.algorithm.KMeansClustering"
         )
         assert (
             config.get_value("SampleSearch.Clustering.Fire")
-            == "adf.impl.module.algorithm.KMeansClustering"
+            == "adf_core_python.implement.module.algorithm.KMeansClustering"
         )
         assert (
             config.get_value("SampleSearch.Clustering.Police")
-            == "adf.impl.module.algorithm.KMeansClustering"
+            == "adf_core_python.implement.module.algorithm.KMeansClustering"
         )
 
     def test_if_file_not_found(self) -> None:

--- a/tests/core/agent/module/module.yaml
+++ b/tests/core/agent/module/module.yaml
@@ -2,122 +2,122 @@
 DefaultTacticsAmbulanceTeam:
   HumanDetector: sample_team.module.complex.SampleHumanDetector
   Search: sample_team.module.complex.SampleSearch
-  ExtActionTransport: adf.impl.extaction.DefaultExtActionTransport
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
-  CommandExecutorAmbulance: adf.impl.centralized.DefaultCommandExecutorAmbulance
-  CommandExecutorScout: adf.impl.centralized.DefaultCommandExecutorScout
+  ExtendActionTransport: adf_core_python.implement.action.DefaultExtendActionTransport
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
+  CommandExecutorAmbulance: adf_core_python.implement.centralized.DefaultCommandExecutorAmbulance
+  CommandExecutorScout: adf_core_python.implement.centralized.DefaultCommandExecutorScout
 
 ## DefaultTacticsFireBrigade
 DefaultTacticsFireBrigade:
   HumanDetector: sample_team.module.complex.SampleHumanDetector
   Search: sample_team.module.complex.SampleSearch
-  ExtActionFireRescue: adf.impl.extaction.DefaultExtActionFireRescue
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
-  CommandExecutorFire: adf.impl.centralized.DefaultCommandExecutorFire
-  CommandExecutorScout: adf.impl.centralized.DefaultCommandExecutorScout
+  ExtendActionRescue: adf_core_python.implement.action.DefaultExtendActionRescue
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
+  CommandExecutorFire: adf_core_python.implement.centralized.DefaultCommandExecutorFire
+  CommandExecutorScout: adf_core_python.implement.centralized.DefaultCommandExecutorScout
 
 ## DefaultTacticsPoliceForce
 DefaultTacticsPoliceForce:
   RoadDetector: sample_team.module.complex.SampleRoadDetector
   Search: sample_team.module.complex.SampleSearch
-  ExtActionClear: adf.impl.extaction.DefaultExtActionClear
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
-  CommandExecutorPolice: adf.impl.centralized.DefaultCommandExecutorPolice
-  CommandExecutorScout: adf.impl.centralized.DefaultCommandExecutorScoutPolice
+  ExtendActionClear: adf_core_python.implement.action.DefaultExtendActionClear
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
+  CommandExecutorPolice: adf_core_python.implement.centralized.DefaultCommandExecutorPolice
+  CommandExecutorScout: adf_core_python.implement.centralized.DefaultCommandExecutorScoutPolice
 
 ## DefaultTacticsAmbulanceCentre
 DefaultTacticsAmbulanceCentre:
   TargetAllocator: sample_team.module.complex.SampleAmbulanceTargetAllocator
-  CommandPicker: adf.impl.centralized.DefaultCommandPickerAmbulance
+  CommandPicker: adf_core_python.implement.centralized.DefaultCommandPickerAmbulance
 
 ## DefaultTacticsFireStation
 DefaultTacticsFireStation:
   TargetAllocator: sample_team.module.complex.SampleFireTargetAllocator
-  CommandPicker: adf.impl.centralized.DefaultCommandPickerFire
+  CommandPicker: adf_core_python.implement.centralized.DefaultCommandPickerFire
 
 ## DefaultTacticsPoliceOffice
 DefaultTacticsPoliceOffice:
   TargetAllocator: sample_team.module.complex.SamplePoliceTargetAllocator
-  CommandPicker: adf.impl.centralized.DefaultCommandPickerPolice
+  CommandPicker: adf_core_python.implement.centralized.DefaultCommandPickerPolice
 
 ## SampleSearch
 SampleSearch:
   PathPlanning:
-    Ambulance: adf.impl.module.algorithm.DijkstraPathPlanning
-    Fire: adf.impl.module.algorithm.DijkstraPathPlanning
-    Police: adf.impl.module.algorithm.DijkstraPathPlanning
+    Ambulance: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+    Fire: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+    Police: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
   Clustering:
-    Ambulance: adf.impl.module.algorithm.KMeansClustering
-    Fire: adf.impl.module.algorithm.KMeansClustering
-    Police: adf.impl.module.algorithm.KMeansClustering
+    Ambulance: adf_core_python.implement.module.algorithm.KMeansClustering
+    Fire: adf_core_python.implement.module.algorithm.KMeansClustering
+    Police: adf_core_python.implement.module.algorithm.KMeansClustering
 
 ## SampleBuildDetector
 SampleBuildingDetector:
-  Clustering: adf.impl.module.algorithm.KMeansClustering
+  Clustering: adf_core_python.implement.module.algorithm.KMeansClustering
 
 ## SampleRoadDetector
 SampleRoadDetector:
-  Clustering: adf.impl.module.algorithm.KMeansClustering
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+  Clustering: adf_core_python.implement.module.algorithm.KMeansClustering
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
 ## SampleHumanDetector
 SampleHumanDetector:
-  Clustering: adf.impl.module.algorithm.KMeansClustering
+  Clustering: adf_core_python.implement.module.algorithm.KMeansClustering
 
-## DefaultExtActionClear
-DefaultExtActionClear:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+## DefaultExtendActionClear
+DefaultExtendActionClear:
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-## DefaultExtActionFireFighting
-DefaultExtActionFireFighting:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+## DefaultExtendActionFireFighting
+DefaultExtendActionFireFighting:
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-## DefaultExtActionFireRescue
-DefaultExtActionFireRescue:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+## DefaultExtendActionRescue
+DefaultExtendActionRescue:
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-## DefaultExtActionMove
-DefaultExtActionMove:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+## DefaultExtendActionMove
+DefaultExtendActionMove:
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
-## DefaultExtActionTransport
-DefaultExtActionTransport:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+## DefaultExtendActionTransport
+DefaultExtendActionTransport:
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
 ## DefaultCommandExecutorAmbulance
 DefaultCommandExecutorAmbulance:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-  ExtActionTransport: adf.impl.extaction.DefaultExtActionTransport
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+  ExtendActionTransport: adf_core_python.implement.action.DefaultExtendActionTransport
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
 
 ## DefaultCommandExecutorFire
 DefaultCommandExecutorFire:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-  EtxActionFireRescue: adf.impl.extaction.DefaultExtActionFireRescue
-  EtxActionFireFighting: adf.impl.extaction.DefaultExtActionFireFighting
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+  EtxActionFireRescue: adf_core_python.implement.action.DefaultExtendActionRescue
+  EtxActionFireFighting: adf_core_python.implement.action.DefaultExtendActionFireFighting
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
 
 ## DefaultCommandExecutorPolice
 DefaultCommandExecutorPolice:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-  ExtActionClear: adf.impl.extaction.DefaultExtActionClear
-  ExtActionMove: adf.impl.extaction.DefaultExtActionMove
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+  ExtendActionClear: adf_core_python.implement.action.DefaultExtendActionClear
+  ExtendActionMove: adf_core_python.implement.action.DefaultExtendActionMove
 
 ## DefaultCommandExecutorScout
 DefaultCommandExecutorScout:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
 
 ## DefaultCommandExecutorScoutPolice
 DefaultCommandExecutorScoutPolice:
-  PathPlanning: adf.impl.module.algorithm.DijkstraPathPlanning
-  ExtActionClear: adf.impl.extaction.DefaultExtActionClear
+  PathPlanning: adf_core_python.implement.module.algorithm.DijkstraPathPlanning
+  ExtendActionClear: adf_core_python.implement.action.DefaultExtendActionClear
 
 ## MessageManager
 MessageManager:
-  PlatoonChannelSubscriber: adf.impl.module.comm.DefaultChannelSubscriber
-  CenterChannelSubscriber: adf.impl.module.comm.DefaultChannelSubscriber
-  PlatoonMessageCoordinator: adf.impl.module.comm.DefaultMessageCoordinator
-  CenterMessageCoordinator: adf.impl.module.comm.DefaultMessageCoordinator
+  PlatoonChannelSubscriber: adf_core_python.implement.module.comm.DefaultChannelSubscriber
+  CenterChannelSubscriber: adf_core_python.implement.module.comm.DefaultChannelSubscriber
+  PlatoonMessageCoordinator: adf_core_python.implement.module.comm.DefaultMessageCoordinator
+  CenterMessageCoordinator: adf_core_python.implement.module.comm.DefaultMessageCoordinator
 
 ## VisualDebug
 VisualDebug: true


### PR DESCRIPTION
Rename modules from "ExtAction" to "ExtendAction" or "Action"