### PR TITLE
Fix response confirmation position and reduce thread wait time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adf_core_python"
-version = "0.2.12"
+version = "0.2.13"
 description = "Agent Development Framework for Python"
 readme = "README.md"
 authors = [

--- a/src/adf_core_python/core/agent/agent.py
+++ b/src/adf_core_python/core/agent/agent.py
@@ -282,8 +282,9 @@ class Agent:
       for key, value in config.data.items():
         self.config.set_value(key, value)
 
-    self.send_acknowledge(msg.request_id)
     self.post_connect()
+
+    self.send_acknowledge(msg.request_id)
     self.logger.info(
       f"Connected to kernel: {self.__class__.__qualname__} (request_id: {msg.request_id}, agent_id: {self.agent_id}, mode: {self._mode})",
       request_id=msg.request_id,

--- a/src/adf_core_python/core/launcher/agent_launcher.py
+++ b/src/adf_core_python/core/launcher/agent_launcher.py
@@ -108,7 +108,7 @@ class AgentLauncher:
       ) -> None:
         for thread, event in threads.items():
           thread.start()
-          event.wait(5)
+          event.wait(1)
 
       connector_thread = threading.Thread(
         target=start_connector_threads, args=(threads,)

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-03-31T04:22:55.504458416Z"
+exclude-newer = "2026-03-31T07:15:12.529465123Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -20,7 +20,7 @@ wheels = [
 
 [[package]]
 name = "adf-core-python"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "bitarray" },


### PR DESCRIPTION
This pull request includes a version bump for the `adf_core_python` package and minor improvements to connection handling and thread startup timing. The main changes are focused on improving the responsiveness of thread initialization and ensuring proper ordering in connection acknowledgment.

Core logic improvements:

* Moved the call to `send_acknowledge` after `post_connect` in `handle_connect_ok` to ensure that the acknowledgment is sent only after post-connection actions complete.

Threading and performance:

* Reduced the wait time for thread startup from 5 seconds to 1 second in `start_connector_threads`, which should improve startup responsiveness.

Versioning:

* Bumped the package version from `0.2.12` to `0.2.13` in `pyproject.toml`.