### PR TITLE
Add logging for submodule and action restart times

### DIFF
--- a/src/adf_core_python/core/component/module/abstract_module.py
+++ b/src/adf_core_python/core/component/module/abstract_module.py
@@ -59,7 +59,11 @@ class AbstractModule(ABC):
   def resume(self, precompute_data: PrecomputeData) -> AbstractModule:
     self._count_resume += 1
     for sub_module in self._sub_modules:
+      start_time = time.time()
       sub_module.resume(precompute_data)
+      self._logger.debug(
+        f"{self.__class__.__name__}'s sub_module {sub_module.__class__.__name__} resume time: {time.time() - start_time:.3f}",
+      )
     return self
 
   def prepare(self) -> AbstractModule:

--- a/src/adf_core_python/core/component/tactics/tactics_agent.py
+++ b/src/adf_core_python/core/component/tactics/tactics_agent.py
@@ -124,9 +124,17 @@ class TacticsAgent(ABC):
 
   def module_resume(self, precompute_data: PrecomputeData) -> None:
     for module in self._modules:
+      start_time = time.time()
       module.resume(precompute_data)
+      self._logger.debug(
+        f"module {module.__class__.__name__} resume time: {time.time() - start_time:.3f}",
+      )
     for action in self._actions:
+      start_time = time.time()
       action.resume(precompute_data)
+      self._logger.debug(
+        f"action {action.__class__.__name__} resume time: {time.time() - start_time:.3f}",
+      )
     for executor in self._command_executor:
       executor.resume(precompute_data)
 


### PR DESCRIPTION
This pull request adds detailed debug logging to track the time spent resuming modules and actions within the system. These changes will help with performance monitoring and troubleshooting by providing precise timing information for each component's resume operation.

Performance monitoring improvements:

* Added debug logs in `abstract_module.py` to record the time taken for each submodule's `resume` call in the `AbstractModule` class.
* Enhanced `tactics_agent.py` to log the resume time for each module and action in the `TacticsAgent` class, aiding in identifying bottlenecks during the resume process.