### PR TITLE
Fix missing perentheses in `get_position_entity_id` call

### DIFF
--- a/src/adf_core_python/cli/template/src/team_name/module/complex/sample_road_detector.py
+++ b/src/adf_core_python/cli/template/src/team_name/module/complex/sample_road_detector.py
@@ -99,7 +99,7 @@ class SampleRoadDetector(RoadDetector):
       return self
 
     if self._result is not None:
-      if self._agent_info.get_position_entity_id == self._result:
+      if self._agent_info.get_position_entity_id() == self._result:
         entity = self._world_info.get_entity(self._result)
         if isinstance(entity, Building):
           self._result = None

--- a/src/adf_core_python/implement/module/complex/default_road_detector.py
+++ b/src/adf_core_python/implement/module/complex/default_road_detector.py
@@ -99,7 +99,7 @@ class DefaultRoadDetector(RoadDetector):
       return self
 
     if self._result is not None:
-      if self._agent_info.get_position_entity_id == self._result:
+      if self._agent_info.get_position_entity_id() == self._result:
         entity = self._world_info.get_entity(self._result)
         if isinstance(entity, Building):
           self._result = None


### PR DESCRIPTION
It seems the method was being referenced as an object instread of being called. Please review this fix.